### PR TITLE
[MERGE] chapter 12 into main

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -6,9 +6,9 @@
     'data': [
         'security/ir.model.access.csv',
         'views/estate_property_views.xml',
-        'views/estate_property_type_views.xml',
         'views/estate_property_tag_views.xml',
         'views/estate_property_offer_views.xml',
+        'views/estate_property_type_views.xml',
         'views/estate_menus.xml',
     ],
     'application': True,

--- a/models/estate_property.py
+++ b/models/estate_property.py
@@ -7,6 +7,7 @@ from odoo.exceptions import UserError, ValidationError
 class EstateProperty(models.Model):
     _name = 'estate.property'
     _description = 'An estate property listing.'
+    _order = "id desc"
 
     tag_ids = fields.Many2many("estate.property.tag", string="Tags")
     property_type_id = fields.Many2one('estate.property.type', string='Property Type')

--- a/models/estate_property.py
+++ b/models/estate_property.py
@@ -111,8 +111,8 @@ class EstateProperty(models.Model):
     def _check_selling_price(self):
         for record in self:
             if fields.float_is_zero(record.selling_price, precision_digits=2):
-                # No offer has been accepted yet, no need to enforce.
-                return
+                # No offer has been accepted yet
+                continue
             if fields.float_compare(record.selling_price, record.expected_price * .90, precision_digits=2) < 0:
                 if record.state == 'offer_accepted':
                     message = 'The selling price must be at least 90% of the expected price!'

--- a/models/estate_property_offer.py
+++ b/models/estate_property_offer.py
@@ -19,6 +19,7 @@ class EstatePropertyOffer(models.Model):
     )
     partner_id = fields.Many2one('res.partner', required=True, string='Partner')
     property_id = fields.Many2one('estate.property', required=True, string='Property')
+    property_type_id = fields.Many2one(related='property_id.property_type_id', store=True)
 
     def action_accept_offer(self):
         for record in self:

--- a/models/estate_property_offer.py
+++ b/models/estate_property_offer.py
@@ -6,6 +6,7 @@ from odoo.exceptions import UserError
 class EstatePropertyOffer(models.Model):
     _name = 'estate.property.offer'
     _description = 'An amount a potential buyer offers to the seller for a property.'
+    _order = "price desc"
 
     # Status
     price = fields.Float()

--- a/models/estate_property_offer.py
+++ b/models/estate_property_offer.py
@@ -23,7 +23,7 @@ class EstatePropertyOffer(models.Model):
     def action_accept_offer(self):
         for record in self:
             property_record = record.property_id
-            if property_record.state == 'offer_accepted':
+            if property_record.state == 'offer_accepted' or property_record.state == 'sold':
                 raise UserError('An offer has already been accepted.')
 
             # Update related property listing

--- a/models/estate_property_tag.py
+++ b/models/estate_property_tag.py
@@ -4,6 +4,7 @@ from odoo import models, fields
 class EstatePropertyTag(models.Model):
     _name = 'estate.property.tag'
     _description = 'Multiple tags can be associated to multiple properties to aid description and search.'
+    _order = "name"
 
     name = fields.Char(required=True)
 

--- a/models/estate_property_tag.py
+++ b/models/estate_property_tag.py
@@ -7,6 +7,7 @@ class EstatePropertyTag(models.Model):
     _order = "name"
 
     name = fields.Char(required=True)
+    color = fields.Integer()
 
     # Constraints
     _sql_constraints = [

--- a/models/estate_property_type.py
+++ b/models/estate_property_type.py
@@ -6,6 +6,7 @@ class EstatePropertyType(models.Model):
     _description = 'Represents the type of property that is listed.'
 
     name = fields.Char(required=True)
+    property_ids = fields.One2many('estate.property', 'property_type_id')
 
     # Constraints
     _sql_constraints = [

--- a/models/estate_property_type.py
+++ b/models/estate_property_type.py
@@ -9,6 +9,15 @@ class EstatePropertyType(models.Model):
     sequence = fields.Integer('Sequence', default=1, help="Used to order stages. Lower is better.")
     name = fields.Char(required=True)
     property_ids = fields.One2many('estate.property', 'property_type_id')
+    offer_ids = fields.One2many('estate.property.offer', 'property_type_id')
+    offer_count = fields.Integer(string='Offers', compute='_compute_offer_count', default=0)
+
+    def _compute_offer_count(self):
+        for record in self:
+            if record.offer_ids:
+                record.offer_count = len(record.offer_ids)
+            else:
+                record.offer_count = 0
 
     # Constraints
     _sql_constraints = [

--- a/models/estate_property_type.py
+++ b/models/estate_property_type.py
@@ -4,8 +4,9 @@ from odoo import models, fields
 class EstatePropertyType(models.Model):
     _name = 'estate.property.type'
     _description = 'Represents the type of property that is listed.'
-    _order = "name"
+    _order = "sequence, name"
 
+    sequence = fields.Integer('Sequence', default=1, help="Used to order stages. Lower is better.")
     name = fields.Char(required=True)
     property_ids = fields.One2many('estate.property', 'property_type_id')
 

--- a/models/estate_property_type.py
+++ b/models/estate_property_type.py
@@ -4,6 +4,7 @@ from odoo import models, fields
 class EstatePropertyType(models.Model):
     _name = 'estate.property.type'
     _description = 'Represents the type of property that is listed.'
+    _order = "name"
 
     name = fields.Char(required=True)
     property_ids = fields.One2many('estate.property', 'property_type_id')

--- a/views/estate_property_offer_views.xml
+++ b/views/estate_property_offer_views.xml
@@ -25,7 +25,7 @@
         <field name="name">estate.property.offer.tree</field>
         <field name="model">estate.property.offer</field>
         <field name="arch" type="xml">
-            <tree string="Offer">
+            <tree string="Offer" editable="bottom">
                 <field name="price"/>
                 <field name="partner_id"/>
                 <field name="validity"/>

--- a/views/estate_property_offer_views.xml
+++ b/views/estate_property_offer_views.xml
@@ -25,14 +25,14 @@
         <field name="name">estate.property.offer.tree</field>
         <field name="model">estate.property.offer</field>
         <field name="arch" type="xml">
-            <tree string="Offer" editable="bottom">
+            <tree string="Offer" editable="bottom" decoration-success="status=='accepted'" decoration-danger="status=='refused'">
                 <field name="price"/>
                 <field name="partner_id"/>
                 <field name="validity"/>
                 <field name="date_deadline"/>
                 <button name="action_accept_offer" type="object" class="btn fa fa-check" string="" title="Accept" aria-label="Accept" attrs="{'invisible': ['|', ('status', '=', 'accepted'), ('status', '=', 'refused')] }"/>
                 <button name="action_refuse_offer" type="object" class="btn fa fa-times" string="" title="Refuse" aria-label="Refuse" attrs="{'invisible': ['|', ('status', '=', 'accepted'), ('status', '=', 'refused')] }"/>
-                <field name="status"/>
+                <field name="status" invisible="1"/>
             </tree>
         </field>
     </record>

--- a/views/estate_property_offer_views.xml
+++ b/views/estate_property_offer_views.xml
@@ -30,8 +30,8 @@
                 <field name="partner_id"/>
                 <field name="validity"/>
                 <field name="date_deadline"/>
-                <button name="action_accept_offer" type="object" class="btn fa fa-check" string="" title="Accept" aria-label="Accept"/>
-                <button name="action_refuse_offer" type="object" class="btn fa fa-times" string="" title="Refuse" aria-label="Refuse"/>
+                <button name="action_accept_offer" type="object" class="btn fa fa-check" string="" title="Accept" aria-label="Accept" attrs="{'invisible': ['|', ('status', '=', 'accepted'), ('status', '=', 'refused')] }"/>
+                <button name="action_refuse_offer" type="object" class="btn fa fa-times" string="" title="Refuse" aria-label="Refuse" attrs="{'invisible': ['|', ('status', '=', 'accepted'), ('status', '=', 'refused')] }"/>
                 <field name="status"/>
             </tree>
         </field>

--- a/views/estate_property_offer_views.xml
+++ b/views/estate_property_offer_views.xml
@@ -37,4 +37,11 @@
         </field>
     </record>
 
+    <record id="estate_offer_action" model="ir.actions.act_window">
+        <field name="name">Property Offers</field>
+        <field name="res_model">estate.property.offer</field>
+        <field name="view_mode">tree,form</field>
+        <field name="domain">[('property_type_id', '=', active_id)]</field>
+    </record>
+
 </odoo>

--- a/views/estate_property_tag_views.xml
+++ b/views/estate_property_tag_views.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <odoo>
 
-    <record id="estate_property_tag_view_form" model="ir.ui.view">
+    <!--<record id="estate_property_tag_view_form" model="ir.ui.view">
         <field name="name">estate.property.tag.tree</field>
         <field name="model">estate.property.tag</field>
         <field name="arch" type="xml">
@@ -14,6 +14,16 @@
                 </sheet>
             </form>
 
+        </field>
+    </record>-->
+
+    <record id="estate_property_tag_view_tree" model="ir.ui.view">
+        <field name="name">estate.property.tag.tree</field>
+        <field name="model">estate.property.tag</field>
+        <field name="arch" type="xml">
+            <tree string="Tag" editable="bottom">
+                <field name="name"/>
+            </tree>
         </field>
     </record>
 

--- a/views/estate_property_type_views.xml
+++ b/views/estate_property_type_views.xml
@@ -11,6 +11,18 @@
                     <h1>
                         <field name="name"/>
                     </h1>
+                    <br/>
+                    <notebook>
+                        <page string="Properties">
+                            <field name="property_ids">
+                                <tree>
+                                    <field name="name"/>
+                                    <field name="expected_price"/>
+                                    <field name="state"/>
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
                 </sheet>
             </form>
 

--- a/views/estate_property_type_views.xml
+++ b/views/estate_property_type_views.xml
@@ -13,7 +13,7 @@
     </record>
 
     <record id="estate_property_type_view_form" model="ir.ui.view">
-        <field name="name">estate.property.type.tree</field>
+        <field name="name">estate.property.type.form</field>
         <field name="model">estate.property.type</field>
         <field name="arch" type="xml">
             <form string="Property Type">

--- a/views/estate_property_type_views.xml
+++ b/views/estate_property_type_views.xml
@@ -1,11 +1,21 @@
 <?xml version="1.0"?>
 <odoo>
 
+    <record id="estate_property_type_view_tree" model="ir.ui.view">
+        <field name="name">estate.property.type.tree</field>
+        <field name="model">estate.property.type</field>
+        <field name="arch" type="xml">
+            <tree string="Property Types">
+                <field name="sequence" widget="handle"/>
+                <field name="name"/>
+            </tree>
+        </field>
+    </record>
+
     <record id="estate_property_type_view_form" model="ir.ui.view">
         <field name="name">estate.property.type.tree</field>
         <field name="model">estate.property.type</field>
         <field name="arch" type="xml">
-
             <form string="Property Type">
                 <sheet>
                     <h1>
@@ -25,7 +35,6 @@
                     </notebook>
                 </sheet>
             </form>
-
         </field>
     </record>
 

--- a/views/estate_property_type_views.xml
+++ b/views/estate_property_type_views.xml
@@ -18,6 +18,13 @@
         <field name="arch" type="xml">
             <form string="Property Type">
                 <sheet>
+                    <div name="button_box" class="oe_button_box">
+                        <button type="action" name="%(estate_offer_action)d" string="Property Offers" class="oe_stat_button" icon="fa-money">
+                            <span>
+                                <field name="offer_count"/> Offers
+                            </span>
+                        </button>
+                    </div>
                     <h1>
                         <field name="name"/>
                     </h1>

--- a/views/estate_property_views.xml
+++ b/views/estate_property_views.xml
@@ -29,8 +29,8 @@
 
             <form string="Estate Property">
                 <header>
-                    <button name="action_sold_property" type="object" string="Sold"/>
-                    <button name="action_cancel_property" type="object" string="Cancel"/>
+                    <button name="action_sold_property" type="object" string="Sold" states="new,offer_received,offer_accepted"/>
+                    <button name="action_cancel_property" type="object" string="Cancel" states="new,offer_received,offer_accepted"/>
                     <field name="state" widget="statusbar"/>
                 </header>
                 <sheet>

--- a/views/estate_property_views.xml
+++ b/views/estate_property_views.xml
@@ -31,6 +31,7 @@
                 <header>
                     <button name="action_sold_property" type="object" string="Sold"/>
                     <button name="action_cancel_property" type="object" string="Cancel"/>
+                    <field name="state" widget="statusbar"/>
                 </header>
                 <sheet>
                     <h1>

--- a/views/estate_property_views.xml
+++ b/views/estate_property_views.xml
@@ -10,10 +10,10 @@
                 <field name="postcode"/>
                 <field name="expected_price"/>
                 <field name="bedrooms"/>
-                <field name="living_area"/>
+                <field name="living_area" string="Living Area (sqm)"
+                       filter_domain="[('living_area', '>=', self)]"/>
                 <field name="facades"/>
-                <separator/>
-                <filter string="Available" name="available_filter"
+                <filter string="Available" name="available"
                         domain="['|', ('state', '=', 'new'), ('state', '=', 'offer_received')]"/>
                 <group expand="1" string="Group By">
                     <filter string="Postcode" name="postcode_group" context="{'group_by':'postcode'}"/>
@@ -69,7 +69,7 @@
                             </group>
                         </page>
                         <page string="Offers">
-                            <field name="offer_ids" attrs="{'readonly': ['|', ('state', '=', 'sold'), '|', ('state', '=', 'offer_accepted'), ('state', '=', 'canceled')] }"/>
+                            <field name="offer_ids" attrs="{'readonly': ['|', ('state', '=', 'sold'), '|', ('state', '=', 'offer_accepted'), ('state', '=', 'canceled')]}"/>
                         </page>
                         <page string="Other Info">
                             <br/>

--- a/views/estate_property_views.xml
+++ b/views/estate_property_views.xml
@@ -63,8 +63,8 @@
                                 <field name="facades"/>
                                 <field name="garage"/>
                                 <field name="garden"/>
-                                <field name="garden_area"/>
-                                <field name="garden_orientation"/>
+                                <field name="garden_area" attrs="{'invisible': [('garden', '=', False)]}"/>
+                                <field name="garden_orientation" attrs="{'invisible': [('garden', '=', False)]}"/>
                                 <field name="total_area"/>
                             </group>
                         </page>

--- a/views/estate_property_views.xml
+++ b/views/estate_property_views.xml
@@ -96,7 +96,7 @@
                 <field name="living_area"/>
                 <field name="expected_price"/>
                 <field name="selling_price"/>
-                <field name="date_availability"/>
+                <field name="date_availability" optional="hide"/>
             </tree>
         </field>
     </record>

--- a/views/estate_property_views.xml
+++ b/views/estate_property_views.xml
@@ -92,6 +92,7 @@
             <tree string="Property" decoration-success="state in ['offer_received', 'offer_accepted']" decoration-bf="state=='offer_accepted'" decoration-muted="state=='sold'">
                 <field name="name"/>
                 <field name="postcode"/>
+                <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                 <field name="bedrooms"/>
                 <field name="living_area"/>
                 <field name="expected_price"/>

--- a/views/estate_property_views.xml
+++ b/views/estate_property_views.xml
@@ -89,7 +89,7 @@
         <field name="name">estate.property.tree</field>
         <field name="model">estate.property</field>
         <field name="arch" type="xml">
-            <tree string="Property">
+            <tree string="Property" decoration-success="state in ['offer_received', 'offer_accepted']" decoration-bf="state=='offer_accepted'" decoration-muted="state=='sold'">
                 <field name="name"/>
                 <field name="postcode"/>
                 <field name="bedrooms"/>
@@ -97,6 +97,7 @@
                 <field name="expected_price"/>
                 <field name="selling_price"/>
                 <field name="date_availability" optional="hide"/>
+                <field name="state" invisible="1"/>
             </tree>
         </field>
     </record>

--- a/views/estate_property_views.xml
+++ b/views/estate_property_views.xml
@@ -42,7 +42,7 @@
                     <br/>
                     <group>
                         <group>
-                            <field name="property_type_id"/>
+                            <field name="property_type_id" options="{'no_create': True}"/>
                             <field name="postcode"/>
                             <field name="date_availability"/>
                         </group>

--- a/views/estate_property_views.xml
+++ b/views/estate_property_views.xml
@@ -37,7 +37,7 @@
                     <h1>
                         <field name="name"/>
                     </h1>
-                    <field name="tag_ids" widget="many2many_tags"/>
+                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                     <br/>
                     <br/>
                     <group>

--- a/views/estate_property_views.xml
+++ b/views/estate_property_views.xml
@@ -69,7 +69,7 @@
                             </group>
                         </page>
                         <page string="Offers">
-                            <field name="offer_ids"/>
+                            <field name="offer_ids" attrs="{'readonly': ['|', ('state', '=', 'sold'), '|', ('state', '=', 'offer_accepted'), ('state', '=', 'canceled')] }"/>
                         </page>
                         <page string="Other Info">
                             <br/>

--- a/views/estate_property_views.xml
+++ b/views/estate_property_views.xml
@@ -98,6 +98,7 @@
         <field name="name">Properties</field>
         <field name="res_model">estate.property</field>
         <field name="view_mode">tree,form</field>
+        <field name="context">{'search_default_available': True}</field>
     </record>
 
 </odoo>

--- a/views/estate_property_views.xml
+++ b/views/estate_property_views.xml
@@ -2,7 +2,7 @@
 <odoo>
 
     <record id="estate_property_search" model="ir.ui.view">
-        <field name="name">estate.property.tree</field>
+        <field name="name">estate.property.search</field>
         <field name="model">estate.property</field>
         <field name="arch" type="xml">
             <search string="Estate Property">
@@ -23,7 +23,7 @@
     </record>
 
     <record id="estate_property_view_form" model="ir.ui.view">
-        <field name="name">estate.property.tree</field>
+        <field name="name">estate.property.form</field>
         <field name="model">estate.property</field>
         <field name="arch" type="xml">
 

--- a/views/estate_property_views.xml
+++ b/views/estate_property_views.xml
@@ -6,15 +6,7 @@
         <field name="model">estate.property</field>
         <field name="arch" type="xml">
             <search string="Estate Property">
-                <field name="name"/>
-                <field name="postcode"/>
-                <field name="expected_price"/>
-                <field name="bedrooms"/>
-                <field name="living_area"/>
-                <field name="facades"/>
-                <separator/>
-                <filter string="Available" name="available_filter"
-                        domain="['|', ('state', '=', 'new'), ('state', '=', 'offer_received')]"/>
+                <filter string="Available" name="available" domain="['|', ('state', '=', 'new'), ('state', '=', 'offer_received')]"/>
                 <group expand="1" string="Group By">
                     <filter string="Postcode" name="postcode_group" context="{'group_by':'postcode'}"/>
                 </group>
@@ -69,7 +61,7 @@
                             </group>
                         </page>
                         <page string="Offers">
-                            <field name="offer_ids" attrs="{'readonly': ['|', ('state', '=', 'sold'), '|', ('state', '=', 'offer_accepted'), ('state', '=', 'canceled')] }"/>
+                            <field name="offer_ids" attrs="{'readonly': ['|', ('state', '=', 'sold'), '|', ('state', '=', 'offer_accepted'), ('state', '=', 'canceled')]}"/>
                         </page>
                         <page string="Other Info">
                             <br/>

--- a/views/estate_property_views.xml
+++ b/views/estate_property_views.xml
@@ -6,7 +6,15 @@
         <field name="model">estate.property</field>
         <field name="arch" type="xml">
             <search string="Estate Property">
-                <filter string="Available" name="available" domain="['|', ('state', '=', 'new'), ('state', '=', 'offer_received')]"/>
+                <field name="name"/>
+                <field name="postcode"/>
+                <field name="expected_price"/>
+                <field name="bedrooms"/>
+                <field name="living_area"/>
+                <field name="facades"/>
+                <separator/>
+                <filter string="Available" name="available_filter"
+                        domain="['|', ('state', '=', 'new'), ('state', '=', 'offer_received')]"/>
                 <group expand="1" string="Group By">
                     <filter string="Postcode" name="postcode_group" context="{'group_by':'postcode'}"/>
                 </group>
@@ -61,7 +69,7 @@
                             </group>
                         </page>
                         <page string="Offers">
-                            <field name="offer_ids" attrs="{'readonly': ['|', ('state', '=', 'sold'), '|', ('state', '=', 'offer_accepted'), ('state', '=', 'canceled')]}"/>
+                            <field name="offer_ids" attrs="{'readonly': ['|', ('state', '=', 'sold'), '|', ('state', '=', 'offer_accepted'), ('state', '=', 'canceled')] }"/>
                         </page>
                         <page string="Other Info">
                             <br/>


### PR DESCRIPTION
- Added specific list of properties to the property type view
- The state of the property is now displayed using a specific widget
- All lists are display by default in a deterministic order. Property types can be ordered manually
- Property form view now has conditional display of buttons and fields and Tag colors
- Property and Offer list views now have color decorations
- Availability Date is now hidden by default in Property list view
- Offers and Tags are now editable directly in their list view
- The available properties are filtered by default, and searching on the living area returns results where the area is larger than the given number
- Added a stat button on the property type form view which shows the list of all offers related to properties of the given type when it is clicked on